### PR TITLE
- Fix for a breaking change in `puppet-stdlib` version 8.3.0 (https:/…

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,34 @@
+# devcontainer
+
+
+For format details, see https://aka.ms/devcontainer.json. 
+
+For config options, see the README at:
+https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
+ 
+``` json
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	]
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pdk --version",
+}
+```
+
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,17 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
 {
 	"name": "Puppet Development Kit (Community)",
 	"dockerFile": "Dockerfile",
 
-	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
 	},
 
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
 		"rebornix.Ruby"
 	]
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pdk --version",
 }

--- a/.sync.yml
+++ b/.sync.yml
@@ -24,6 +24,8 @@ appveyor.yml:
   user: rehanone
   secure: "WiS9j4aI93DobVH/O/z6aHKOY8UL2hwn4+fflKuhvZzJPxfsYYfvQsyX43qetpVAIW7DCZLfO1QQlLF1/ywhe8Y9XRy923R6E7WckYPCGtGBpeTdS7p3Biss2H+ikxI9/5UFlewrdFxLxqgKz8lGLCt8zL1r7ggPWjJBfWEBtk2J9mj4BRTTGt6SWTSHwkdqjloQsPu32SXWY4nsU+87p+lO49YTOH2cS+54/DRCpccPl2AL+kXISDGiDZtlMyGdL2c0Z1e8etmOxbHN2X80YyOQY2GiKdGhzVfx5TDPElDXkOO5JkkZWmsz2D6BJYvu+s9awIJ6/pzGFDghZIK2MSgfUjJd9Vwt1lm48kHKsJ3DsSRIOHK+2ft/3nUl8y7j7KKQMcKKVN35/0uy/cXnD4acuxCh84e5bc0pmYy0gxLhLF6C9Ahv8pls7HhA+jaoUBNXIgCb685w6EgrkaeGMx1vz7VfZo56viod/zZ7XCXg8o5s7vthKMtYLnuGIEl2DvBC3KKtGvl4RnzFVUcZcB5lHgLZozskcwuWFtqd/AgqdIVRzKc6KmRWo8TkE/qOV79MaUpKGONmLMQfsz01HMn4m/NAmu4J55kFgFYkrkwy+9c/3Z9Ytce7goOnyxYYd0fFfaSM8vJCl7oe8Zb3znK2atMmpQAfDwYBwUNe1jU="
   docker_sets:
+    - set: ubuntu2204-64
+      collection: puppet7
     - set: ubuntu2004-64
       collection: puppet7
     - set: ubuntu2004-64
@@ -35,8 +37,6 @@ appveyor.yml:
     - set: ubuntu1604-64
       collection: puppet7
     - set: ubuntu1604-64
-      collection: puppet6
-    - set: ubuntu1404-64
       collection: puppet6
     - set: debian10-64
       collection: puppet7

--- a/Rakefile
+++ b/Rakefile
@@ -44,6 +44,7 @@ end
 PuppetLint.configuration.send('disable_relative')
 PuppetLint.configuration.fail_on_warnings = true
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?

--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -3,12 +3,12 @@ class bht::dependencies () inherits bht {
   assert_private("Use of private class ${name} by ${caller_module_name}")
 
   if $bht::manage {
-    ensure_packages([$bht::core_dependencies], { 'ensure' => present })
+    package { [$bht::core_dependencies]: ensure => installed }
 
-    ensure_packages([$bht::additional_dependencies], { 'ensure' => $bht::ensure })
+    package { [$bht::additional_dependencies]: ensure => $bht::ensure }
   }
 
   if $bht::git_manage {
-    ensure_packages([$bht::git_package], { 'ensure' => $bht::ensure })
+    package { [$bht::git_package]: ensure => $bht::ensure }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -104,7 +104,7 @@
     "Disk Burnin",
     "Hard Drive Testing"
   ],
-  "pdk-version": "2.2.0",
-  "template-url": "pdk-default#2.2.0",
-  "template-ref": "tags/2.2.0-0-g2381db6"
+  "pdk-version": "2.4.0",
+  "template-url": "pdk-default#2.4.0",
+  "template-ref": "tags/2.4.0-0-gfa6b6d2"
 }


### PR DESCRIPTION
…/github.com/puppetlabs/puppetlabs-stdlib/pull/1196)

- Updated `pdk` template version.
- Added unit test coverage for Ubuntu 22.04.
- Removed test coverage for Ubuntu 14.04.